### PR TITLE
(fix)  Exports should reference the result of getSync / getAsync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,16 +42,22 @@ export function startupApp() {
  * will be `openmrsSpaBase() + 'hello'`, which is usually
  * `/openmrs/spa/hello`.
  */
-export const hello = () => getAsyncLifecycle(() => import("./hello"), options);
+export const hello = getAsyncLifecycle(() => import("./hello"), options);
 
 /**
  * The following are named exports for the extensions defined in this frontend modules. See the `routes.json` file to see how these are used.
  */
-export const redBox = () =>
-  getAsyncLifecycle(() => import("./boxes/extensions/red-box"), options);
+export const redBox = getAsyncLifecycle(
+  () => import("./boxes/extensions/red-box"),
+  options
+);
 
-export const blueBox = () =>
-  getAsyncLifecycle(() => import("./boxes/extensions/blue-box"), options);
+export const blueBox = getAsyncLifecycle(
+  () => import("./boxes/extensions/blue-box"),
+  options
+);
 
-export const brandBox = () =>
-  getAsyncLifecycle(() => import("./boxes/extensions/brand-box"), options);
+export const brandBox = getAsyncLifecycle(
+  () => import("./boxes/extensions/brand-box"),
+  options
+);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

`const export = () => getSyncLifecycle()` should be `const export = getSyncLifecycle()`, etc.
