### PR TITLE
(fix) O3-2538: Editing a default value should update the translation files

### DIFF
--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -76,6 +76,12 @@ module.exports = {
   failOnWarnings: false,
   // Exit with an exit code of 1 on warnings
 
+  resetDefaultValueLocale: 'en',
+  // The locale to compare with default values to determine whether a default value has been changed.
+  // If this is set and a default value differs from a translation in the specified locale, all entries
+  // for that key across locales are reset to the default value, and existing translations are moved to
+  // the `_old` file.
+
   customValueTemplate: null,
   // If you wish to customize the value output the value as an object, you can set your own format.
   // ${defaultValue} is the default value you set in your translation function.


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR updates the translation files if the default value of the translation key is changed.

Referenced issue: https://github.com/i18next/i18next-parser/issues/267
Referenced PR: https://github.com/i18next/i18next-parser/pull/451


## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
https://issues.openmrs.org/browse/O3-2538

## Other
<!-- Anything not covered above -->
<!-- *None* -->
