### PR TITLE
fix(resources): update outdated O3 docs link in resources.component.tsx

### DIFF
--- a/src/resources/resources.component.tsx
+++ b/src/resources/resources.component.tsx
@@ -20,7 +20,7 @@ function Resources() {
         <Card
           title={t('frontendDocs', 'Frontend docs')}
           subtitle={t('learnExplainer', 'Learn how to use the O3 framework') + '.'}
-          link="https://o3-docs.vercel.app"
+          link="https://openmrs.atlassian.net/wiki/spaces/docs/pages/151093495/Introduction+to+O3+for+Developers"
         />
         <Card
           title={t('designDocs', 'Design docs')}


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR updates an outdated documentation link in `resources.component.tsx`.

The original link pointed to a deprecated site:
[https://o3-docs.openmrs.org/](https://o3-docs.openmrs.org/)

It is now updated to the maintained OpenMRS 3.0 Developer Wiki:
[https://openmrs.atlassian.net/wiki/spaces/docs/pages/151093495/Introduction+to+O3+for+Developers](https://openmrs.atlassian.net/wiki/spaces/docs/pages/151093495/Introduction+to+O3+for+Developers)

This helps new developers find the correct documentation when using the esm-template-app.

## Screenshots
*None – this is a link-only text update.*

## Related Issue
*None yet –  was not able to create one since the component section did not have a "esm-template-app"*

## Other
First-time contributor. Happy to make any requested changes!
