### PR TITLE
(feat)O3-5001: Update Template App to Render on Service Queues Page

### DIFF
--- a/e2e/pages/root-page.ts
+++ b/e2e/pages/root-page.ts
@@ -18,7 +18,7 @@ export class RootPage {
   }
 
   async goto() {
-    await this.page.goto('/openmrs/spa/root');
+    await this.page.goto('/openmrs/spa/home/service-queues');
     await this.welcomeHeading.waitFor();
   }
 

--- a/e2e/specs/template-app.spec.ts
+++ b/e2e/specs/template-app.spec.ts
@@ -5,7 +5,7 @@ test('Template app loads and displays all core components', async ({ page }) => 
   const rootPage = new RootPage(page);
   await rootPage.goto();
 
-  await expect(page).toHaveURL(/\/openmrs\/spa\/root/);
+  await expect(page).toHaveURL(/\/openmrs\/spa\/home\/service-queues/);
 
   await expect(rootPage.welcomeHeading).toBeVisible();
   await expect(

--- a/src/routes.json
+++ b/src/routes.json
@@ -24,7 +24,7 @@
   "pages": [
     {
       "component": "root",
-      "route": "root"
+      "route": "home/service-queues"
     }
   ]
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.

## Summary
The Template App was not rendering on the default page in OpenMRS 3.x.  
Since the home page has shifted to **Service Queues** (`/openmrs/spa/home/service-queues`), the app was still pointing to the old, archived home page. This made the template unusable out-of-the-box.  

This PR updates the `src/routes.json` configuration to point the main application component to `/home/service-queues`. This aligns the Template App with the current navigation structure and ensures it renders correctly on a fresh installation.

## Screenshots
*None*

## Related Issue
[Jira Ticket: O3-5001](https://openmrs.atlassian.net/browse/O3-5001)

## Other
*None*
