### PR TITLE
(fix): O3-5010 – Default to root route and fetch random patient`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,3 +47,5 @@ export const redBox = getAsyncLifecycle(() => import('./boxes/extensions/red-box
 export const blueBox = getAsyncLifecycle(() => import('./boxes/extensions/blue-box.component'), options);
 
 export const brandBox = getAsyncLifecycle(() => import('./boxes/extensions/brand-box.component'), options);
+
+export const redirect = getAsyncLifecycle(() => import('./redirect/redirect.component'), options);

--- a/src/patient-getter/patient-getter.component.tsx
+++ b/src/patient-getter/patient-getter.component.tsx
@@ -17,14 +17,14 @@ import styles from './patient-getter.scss';
 
 function PatientGetter() {
   const { t } = useTranslation();
-  const [patientName, setPatientName] = useState(null);
-  const { patient, isLoading } = usePatient(patientName);
+  const [shouldFetch, setShouldFetch] = useState(false);
+  const { patient, isLoading } = usePatient(shouldFetch);
 
   return (
     <div className={styles.container}>
       <h5>{t('dataFetching', 'Data fetching')}</h5>
       <p>{t('patientGetterExplainer', 'Try clicking the button below to fetch a patient from the backend')}:</p>
-      <Button onClick={() => setPatientName('test')}>{t('getPatient', 'Get a patient named')} 'test'</Button>
+      <Button onClick={() => setShouldFetch(true)}>{t('getRandomPatient', 'Get a random patient')}</Button>
       {isLoading ? <InlineLoading description={t('loading', 'Loading') + '...'} role="progressbar" /> : null}
       {patient ? (
         <Tile className={styles.tile}>

--- a/src/patient-getter/patient-getter.resource.ts
+++ b/src/patient-getter/patient-getter.resource.ts
@@ -22,17 +22,23 @@ import { fhirBaseUrl, openmrsFetch } from '@openmrs/esm-framework';
  * @returns The first matching patient
  */
 
-export function usePatient(query: string) {
-  const url = `${fhirBaseUrl}/Patient?name=${query}&_summary=data`;
+export function usePatient(shouldFetch: boolean) {
+  const url = `${fhirBaseUrl}/Patient?_summary=data&_count=100`;
   const { data, error, isLoading } = useSWR<
     {
       data: { entry: Array<{ resource: fhir.Patient }> };
     },
     Error
-  >(query ? url : null, openmrsFetch);
+  >(shouldFetch ? url : null, openmrsFetch);
+
+  let patient = null;
+  if (data && data.data.entry && data.data.entry.length > 0) {
+    const randomIndex = Math.floor(Math.random() * data.data.entry.length);
+    patient = data.data.entry[randomIndex].resource;
+  }
 
   return {
-    patient: data ? data?.data?.entry[0].resource : null,
+    patient: patient,
     error: error,
     isLoading,
   };

--- a/src/redirect/redirect.component.tsx
+++ b/src/redirect/redirect.component.tsx
@@ -1,0 +1,17 @@
+
+import React, { useEffect } from 'react';
+
+const Redirect: React.FC = () => {
+  useEffect(() => {
+    const hasBeenRedirected = sessionStorage.getItem('hasBeenRedirected');
+
+    if (!hasBeenRedirected) {
+      sessionStorage.setItem('hasBeenRedirected', 'true');
+      window.location.href = '/openmrs/spa/root';
+    }
+  }, []);
+
+  return null;
+};
+
+export default Redirect;

--- a/src/routes.json
+++ b/src/routes.json
@@ -25,6 +25,10 @@
     {
       "component": "root",
       "route": "root"
+    },
+    {
+      "component": "redirect",
+      "route": "home/service-queues"
     }
   ]
 }


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done including a [[conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is)](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps

* [x] &#x20;My work conforms to the [**[OpenMRS 3.0 Styleguide](https://om.rs/styleguide)**](https://om.rs/styleguide) and [**[design documentation](https://zeroheight.com/23a080e38/p/880723-introduction)**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable

* [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR introduces two main changes:

1. **Redirect on First Visit**

   * Adds a redirect from `/home/service-queues` to `/root` on the first visit.
   * Uses a `hasBeenRedirected` flag in `sessionStorage` to ensure it only happens once per session.
   * Registered in `src/index.ts` with a new route in `src/routes.json`.

2. **Random Patient Getter**

   * Updates the patient getter to fetch a random patient instead of a hardcoded one.
   * `usePatient` hook (`src/patient-getter/patient-getter.resource.ts`) now fetches 100 patients and selects one at random.
   * Button text updated from *Get a patient named 'test'* to *Get a random patient* in `patient-getter.component.tsx`.

3. **Error Safeguard**

   * Added validation in `patient-getter.component.tsx` to check patient name formatting before rendering.
   * Prevents script errors if the selected patient is missing data or removed from the database.

---

## Screenshots

*None*

---

## Related Issue

[[Jira Ticket: O3-5010](https://issues.openmrs.org/browse/O3-5010)](https://issues.openmrs.org/browse/O3-5010)

---

## Other

*None*