### PR TITLE
(chore) Pin esm-framework peer dependency to 9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "*",
+    "@openmrs/esm-framework": "9.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "16.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,7 +2994,7 @@ __metadata:
     turbo: "npm:^2.5.2"
     typescript: "npm:^5.0.0"
   peerDependencies:
-    "@openmrs/esm-framework": "*"
+    "@openmrs/esm-framework": 9.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 16.x


### PR DESCRIPTION
Change the `@openmrs/esm-framework` peer dependency from `*` (any version) to `9.x` to properly declare framework compatibility and surface mismatches early.