### PR TITLE
docs: recommend the create-o3-app CLI for new modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 ![Node.js CI](https://github.com/openmrs/openmrs-esm-template-app/workflows/Node.js%20CI/badge.svg)
 
+> [!IMPORTANT]
+> **Starting a new frontend module?** The recommended way is now the [`create-o3-app`](https://github.com/openmrs/create-o3-app) CLI, which scaffolds a ready-to-run module in one command:
+>
+> ```sh
+> npm create @openmrs/o3-app@latest my-module-name
+> ```
+>
+> This repository is still useful as a reference for the structure the CLI generates. See the [Create a frontend module](https://o3-docs.openmrs.org/en-US/docs/recipes/create-a-frontend-module) recipe for details.
+
 This repository serves as a template for building OpenMRS frontend modules. For detailed guidance, see the [Creating a Frontend Module](https://openmrs.atlassian.net/wiki/x/rIIBCQ) documentation.
 
 For more information, please see the [OpenMRS Frontend Developer Documentation](https://openmrs.atlassian.net/wiki/x/IABBHg).


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds a note to the top of the README pointing people to the `create-o3-app` CLI as the recommended way to start a new frontend module:

```sh
npm create @openmrs/o3-app@latest my-module-name
```

The repository is otherwise unchanged and stays useful as a reference for the structure the CLI generates. This brings the README in line with the o3-docs "Create a frontend module" recipe, which already presents the CLI as the primary path.

## Screenshots

## Related Issue

## Other

Companion change: openmrs/create-o3-app standardizes its README on the same `npm create @openmrs/o3-app@latest` invocation.
