### PR TITLE
(fix) O3-5808: Fix broken CI status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenMRS ESM Template App
 
-![Node.js CI](https://github.com/openmrs/openmrs-esm-template-app/workflows/Node.js%20CI/badge.svg)
+![OpenMRS CI](https://github.com/openmrs/openmrs-esm-template-app/actions/workflows/ci.yml/badge.svg)
 
 > [!IMPORTANT]
 > **Starting a new frontend module?** The recommended way is now the [`create-o3-app`](https://github.com/openmrs/create-o3-app) CLI, which scaffolds a ready-to-run module in one command:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The CI status badge in the README still points at the old "Node.js CI" workflow name, which returns a 404 since the workflow was renamed to "OpenMRS CI". This updates the badge to use the current ci.yml workflow badge URL.

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5808

## Other
