### PR TITLE
(fix) O3-5809: Fix dead o3-docs links in code comments

### DIFF
--- a/src/boxes/extensions/blue-box.component.tsx
+++ b/src/boxes/extensions/blue-box.component.tsx
@@ -2,7 +2,7 @@
  * This component demonstrates the creation of an extension.
  *
  * Check out the Extension System docs:
- * https://o3-docs.vercel.app/docs/extension-system
+ * https://o3-docs.openmrs.org/en-US/docs/extension-system
  */
 
 import React from 'react';

--- a/src/boxes/extensions/brand-box.component.tsx
+++ b/src/boxes/extensions/brand-box.component.tsx
@@ -2,7 +2,7 @@
  * This component demonstrates the creation of an extension.
  *
  * Check out the Extension System docs:
- * https://o3-docs.vercel.app/docs/extension-system
+ * https://o3-docs.openmrs.org/en-US/docs/extension-system
  */
 
 import React from 'react';

--- a/src/boxes/extensions/red-box.component.tsx
+++ b/src/boxes/extensions/red-box.component.tsx
@@ -2,7 +2,7 @@
  * This component demonstrates the creation of an extension.
  *
  * Check out the Extension System docs:
- * https://o3-docs.vercel.app/docs/extension-system
+ * https://o3-docs.openmrs.org/en-US/docs/extension-system
  */
 
 import React from 'react';

--- a/src/greeter/greeter.component.tsx
+++ b/src/greeter/greeter.component.tsx
@@ -1,7 +1,7 @@
 /**
  * This component demonstrates usage of the config object. Its structure
  * comes from `../config-schema.ts`. For more information about the
- * configuration system, read the docs: https://o3-docs.vercel.app/docs/configuration-system
+ * configuration system, read the docs: https://o3-docs.openmrs.org/en-US/docs/configuration-system
  */
 import React from 'react';
 import { Tile } from '@carbon/react';

--- a/src/root.test.tsx
+++ b/src/root.test.tsx
@@ -13,7 +13,7 @@
  * on things that would be visually apparent to a user.
  *
  * To learn more about how we do testing, see the following resources:
- *   https://o3-docs.vercel.app/docs/frontend-modules/testing
+ *   https://o3-docs.openmrs.org/en-US/docs/frontend-modules/unit-and-integration-testing
  *   https://kentcdodds.com/blog/how-to-know-what-to-test
  *   https://kentcdodds.com/blog/testing-implementation-details
  *   https://kentcdodds.com/blog/common-mistakes-with-react-testing-library


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Code comments in the template app pointed at the old o3-docs.vercel.app preview domain with pre-restructure paths, all of which now return 404. Since the template app is a learning resource, these are links new frontend devs actually follow. This updates them to the equivalent pages on the canonical o3-docs.openmrs.org domain (all verified to return 200).

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5809

## Other
