### PR TITLE
(chore) Bump @openmrs/eslint-config to ^2.1.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 import openmrs from '@openmrs/eslint-config';
 
 export default [
-  { ignores: ['dist/**', 'coverage/**', '**/*.d.tsx'] },
+  { ignores: ['dist/**', 'coverage/**'] },
   ...openmrs,
   {
     rules: {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/eslint-config": "^2.0.0",
+    "@openmrs/eslint-config": "^2.1.0",
     "@openmrs/esm-framework": "next",
     "@openmrs/esm-styleguide": "next",
     "@playwright/test": "^1.52.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,9 +2261,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/eslint-config@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@openmrs/eslint-config@npm:2.0.0"
+"@openmrs/eslint-config@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@openmrs/eslint-config@npm:2.1.0"
   dependencies:
     "@eslint/js": "npm:^9.39.0"
     eslint-config-prettier: "npm:^10.1.8"
@@ -2277,7 +2277,7 @@ __metadata:
   peerDependencies:
     eslint: ^9.39.0
     typescript: ">=5"
-  checksum: 10/9e048e2a43a79365e7fd81ebe8b5d0b7def54ae67614b674f705861df4062eeeaa0a2127a9c713fd76cef9de760140d9014a60155feb158fc67cff1f30b15b51
+  checksum: 10/862013f97f19a03d60089de6511d00b0cc72db4303d6f7cf8f22583bc9663072ce6e223f4fc15409d93bf7cbb83534854b9f8635ca425c7d0180122aabecdcec
   languageName: node
   linkType: hard
 
@@ -2597,7 +2597,7 @@ __metadata:
   resolution: "@openmrs/esm-template-app@workspace:."
   dependencies:
     "@carbon/react": "npm:^1.83.0"
-    "@openmrs/eslint-config": "npm:^2.0.0"
+    "@openmrs/eslint-config": "npm:^2.1.0"
     "@openmrs/esm-framework": "npm:next"
     "@openmrs/esm-styleguide": "npm:next"
     "@playwright/test": "npm:^1.52.0"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Bumps [`@openmrs/eslint-config`](https://github.com/openmrs/openmrs-contrib-eslint-config) to [2.1.0](https://github.com/openmrs/openmrs-contrib-eslint-config/releases/tag/v2.1.0) and removes the `**/*.d.tsx` entry the migration carried over from the old `.eslintignore`. That pattern matches nothing, since declaration files end in `.d.ts`, so this is dead config; the actual declaration file was linted before and still is. The lockfile change is just the two entries for the bump.

Validated with `eslint .` at `--max-warnings 0`, `tsc --noEmit`, and the unit tests.

## Screenshots

## Related Issue

## Other
